### PR TITLE
add react demos page

### DIFF
--- a/src/app/react-demos/page.tsx
+++ b/src/app/react-demos/page.tsx
@@ -1,0 +1,29 @@
+import {IDemo} from "@/types";
+import Link from 'next/link'
+
+/**
+ * should place all demos here
+ */
+const DEMOS = [
+    {title: 'Example Demo(to home)', route: '/'}
+] as IDemo[];
+
+export default function ReactDemos() {
+
+    return (
+        <div className="bg-slate-50 min-h-screen">
+            <h3 className="text-2xl text-center">React Demos</h3>
+            <div>
+                <ul>
+                    {DEMOS.map(demo => (
+                        <li key={demo.route}>
+                            <Link className="text-blue-700 prose prose-a hover:prose-a:text-blue-500 hover:underline" href={demo.route}>
+                                {demo.title}
+                            </Link>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    )
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+
+
+export interface IDemo {
+    title:string;
+    /*
+    * should be unique key
+    */
+    route:string;
+}


### PR DESCRIPTION
#Description

resolve #6 

主要功能，增加一个react demos的导航页面

#screenshots
![1697017261752](https://github.com/madison890000/learn-together-next-js/assets/56706953/df7fe52d-a6ad-417c-b505-ac85dc7969f7)

