### PR TITLE
fix:dark mode of new pages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,7 +10,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --foreground-rgb: 0, 0, 0;
+    --foreground-rgb: 255, 255, 255;
     --background-start-rgb: 0, 0, 0;
     --background-end-rgb: 0, 0, 0;
   }

--- a/src/app/react-demos/page.tsx
+++ b/src/app/react-demos/page.tsx
@@ -12,7 +12,7 @@ const DEMOS = [
 export default function ReactDemos() {
 
   return (
-    <div className="bg-slate-50 min-h-screen">
+    <div className="min-h-screen">
       <h3 className="text-2xl text-center">React Demos</h3>
       <div>
         <ul>

--- a/src/app/react-demos/use-effect/page.tsx
+++ b/src/app/react-demos/use-effect/page.tsx
@@ -28,7 +28,7 @@ export default function useEffectDemo() {
     setTips(`now age is ${age}`)
   }, [age])
   return (
-    <div className="bg-slate-50 min-h-screen m-2 p-2">
+    <div className="min-h-screen m-2 p-2">
       <h3 className="p-2 h3">React useEffect Demo</h3>
       <button onClick={() => {
         setAge(age => age + 1)


### PR DESCRIPTION
# Description
Resolve #12 

Previously, we are trying to fix issue #12 in this PR https://github.com/madison890000/learn-together-next-js/pull/13.

It looks good in react demos pages. However it breaks the index page in dark mode.
### After #13
![1697615304931](https://github.com/madison890000/learn-together-next-js/assets/56706953/90e8fba4-c70d-4e28-94ae-3a1112d96d14)

### Before #13 
![1697615341448](https://github.com/madison890000/learn-together-next-js/assets/56706953/36953199-a9c4-4196-ba41-1b80c88dd241)

# Root Cause
We can tell that change `--foreground-rgb: 255, 255, 255;` to `--foreground-rgb: 0, 0, 0;` in dark mode will just set the color to be Black. This may not be a good solution when dark mode(background is black) on in some pages(index).

# Solution
So the better solution to resolve #12 is:
to remove the `constant` white background(both in dark and light) in react-demos pages.

## Now the Index and react demos looks like:
### Light Mode
![1697615542557](https://github.com/madison890000/learn-together-next-js/assets/56706953/53dbc8c3-120a-413b-a53f-dde90f72748b)
![1697615564967](https://github.com/madison890000/learn-together-next-js/assets/56706953/fcaf6dae-988e-475e-b487-9a1222910e4d)
![1697615577530](https://github.com/madison890000/learn-together-next-js/assets/56706953/5e4a97e3-199c-4584-ac5c-1933b32e6726)

### Dark Mode
![1697615603771](https://github.com/madison890000/learn-together-next-js/assets/56706953/9dd2682c-7df8-408d-8c83-8177143e932f)
![1697615620888](https://github.com/madison890000/learn-together-next-js/assets/56706953/39d94d63-b39a-4cc6-88df-1a9cba26672c)
![1697615632001](https://github.com/madison890000/learn-together-next-js/assets/56706953/aa26fae2-3730-4e71-8de3-bf66a6d2d036)

